### PR TITLE
Search command must now be explicitly evoked

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,12 +18,13 @@ var debugShorthand bool
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "megantory",
-	Short: "megantory searches your AWS accounts really fast",
-	Long:  `TODO`,
+	Short: "Search all your configured AWS profiles - FAST",
+	Long: `
+Search all your configured AWS profiles - FAST`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	Run:  searchCmd.Run,  // by default we run the "search" command
-	Args: searchCmd.Args, // inherit searchCmds args rules, too
+	// Run:  searchCmd.Run,  // by default we run the "search" command
+	// Args: searchCmd.Args, // inherit searchCmds args rules, too
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -11,13 +11,16 @@ import (
 // searchCmd represents the search command
 var searchCmd = &cobra.Command{
 	Use:   "search",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "Searches all the things",
+	Long: `
+* Groks your AWS credentials file for all the profiles defined therein
+* Performs a free-text search against all profiles / regions / supported services
+* Does all the searches mentioned above and processing with a high degree of concurrency
+* Returns a list of found resources with breadcrumbs where to find them
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+Example: megantory search "foobar"
+
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Infoln("Starting the Search CMD")
 		search.Search(strings.Join(args, " "))

--- a/lib/search/search.go
+++ b/lib/search/search.go
@@ -16,6 +16,8 @@ var regionsServices map[string][]string
 
 // Search searches all accounts and all supported services in all regions
 func Search(input string) {
+	profiles = detectProfiles()
+	regionsServices = getAllRegions()
 	log.Infoln("Starting the Search LIB")
 	searchEc2(input)
 }

--- a/lib/search/util.go
+++ b/lib/search/util.go
@@ -9,11 +9,6 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-func init() {
-	profiles = detectProfiles()
-	regionsServices = getAllRegions()
-}
-
 // detectProfiles finds all our profiles defined in ~/.aws/credentials
 // It will skip profiles called "DEFAULT", but include "default"
 // TODO: if AWS Credentials set in env, then override with that, I guess


### PR DESCRIPTION
* Updated Cobra descriptions
* Removed an init function. Lesson learned: Init funcs are not for heavy lifting!