### PR TITLE
More concurrency - more performance

### DIFF
--- a/lib/searchec2/addresses.go
+++ b/lib/searchec2/addresses.go
@@ -13,6 +13,9 @@ import (
 // searchAddresses searches single AWS EC2 region
 func searchAddresses(ec2i ec2Input) {
 	wg := sync.WaitGroup{}
+	service := "ec2"
+	resourceType := "ec2-address"
+	bcr := common.BreadCrumbs(ec2i.profile, ec2i.region, service, resourceType)
 	cAddresses := make(chan ec2.Address)
 	go describeAddresses(ec2i.client, ec2i.profile, cAddresses)
 	for addressL := range cAddresses {
@@ -25,12 +28,12 @@ func searchAddresses(ec2i ec2Input) {
 				result := common.Result{
 					Account:      ec2i.profile,
 					Region:       ec2i.region,
-					Service:      "ec2",
-					ResourceType: "ec2-address",
+					Service:      service,
+					ResourceType: resourceType,
 					ResourceID:   *address.AllocationId,
 					ResourceJSON: address.String(),
 				}
-				log.Debugln("EC2: Matched an address, sending back to the results channel.")
+				log.Debugf("%s: Matched an %s, sending back to the results channel.", bcr, resourceType)
 				ec2i.cResult <- result
 			}
 			wg.Done()

--- a/lib/searchec2/instances.go
+++ b/lib/searchec2/instances.go
@@ -18,7 +18,7 @@ func searchInstances(ec2i ec2Input) {
 	bcr := common.BreadCrumbs(ec2i.profile, ec2i.region, service, resourceType)
 	cInstances := make(chan ec2.Instance)
 	go describeInstances(ec2i.client, cInstances)
-	for instanceL := range cInstances { // Blocked until describeInstances closes chan
+	for instanceL := range cInstances {
 		instance := instanceL
 		wg.Add(1)
 		go func() {
@@ -33,7 +33,7 @@ func searchInstances(ec2i ec2Input) {
 					ResourceID:   *instance.InstanceId,
 					ResourceJSON: instance.String(),
 				}
-				log.Debugf("%s: Matched an instance, sending back to the results channel.", bcr)
+				log.Debugf("%s: Matched an %s, sending back to the results channel.", bcr, resourceType)
 				ec2i.cResult <- result
 			}
 			wg.Done()

--- a/lib/searchec2/instances.go
+++ b/lib/searchec2/instances.go
@@ -46,21 +46,15 @@ func searchInstances(ec2i ec2Input) {
 
 // describeInstances wraps ec2 pagination for DescribeInstances
 func describeInstances(client ec2.Client, c chan<- ec2.Instance) {
-	wg := sync.WaitGroup{}
 	defer close(c)
 	input := &ec2.DescribeInstancesInput{}
 	req := client.DescribeInstancesRequest(input)
 	p := ec2.NewDescribeInstancesPaginator(req)
 	for p.Next(context.TODO()) {
-		wg.Add(1)
-		go func() {
-			for _, runInstancesOutput := range p.CurrentPage().Reservations {
-				for _, instance := range runInstancesOutput.Instances {
-					c <- instance
-				}
+		for _, runInstancesOutput := range p.CurrentPage().Reservations {
+			for _, instance := range runInstancesOutput.Instances {
+				c <- instance
 			}
-			wg.Done()
-		}()
+		}
 	}
-	wg.Wait()
 }

--- a/lib/searchec2/instances.go
+++ b/lib/searchec2/instances.go
@@ -3,6 +3,7 @@ package searchec2
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/Kaurin/megantory/lib/common"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -11,41 +12,57 @@ import (
 
 // searchInstances searches single AWS EC2 region
 func searchInstances(ec2i ec2Input) {
+	wg := sync.WaitGroup{}
 	service := "ec2"
 	resourceType := "ec2-instance"
 	bcr := common.BreadCrumbs(ec2i.profile, ec2i.region, service, resourceType)
 	cInstances := make(chan ec2.Instance)
 	go describeInstances(ec2i.client, cInstances)
-	for instance := range cInstances { // Blocked until describeInstances closes chan
-		instanceLower := strings.ToLower(instance.String())
-		searchStrLower := strings.ToLower(ec2i.searchStr)
-		if strings.Contains(instanceLower, searchStrLower) {
-			result := common.Result{
-				Account:      ec2i.profile,
-				Region:       ec2i.region,
-				Service:      service,
-				ResourceType: resourceType,
-				ResourceID:   *instance.InstanceId,
-				ResourceJSON: instance.String(),
+	for instanceL := range cInstances { // Blocked until describeInstances closes chan
+		instance := instanceL
+		wg.Add(1)
+		go func() {
+			instanceLower := strings.ToLower(instance.String())
+			searchStrLower := strings.ToLower(ec2i.searchStr)
+			if strings.Contains(instanceLower, searchStrLower) {
+				result := common.Result{
+					Account:      ec2i.profile,
+					Region:       ec2i.region,
+					Service:      service,
+					ResourceType: resourceType,
+					ResourceID:   *instance.InstanceId,
+					ResourceJSON: instance.String(),
+				}
+				log.Debugf("%s: Matched an instance, sending back to the results channel.", bcr)
+				ec2i.cResult <- result
 			}
-			log.Debugf("%s: Matched an instance, sending back to the results channel.", bcr)
-			ec2i.cResult <- result
-		}
+		}()
+
 	}
+	wg.Wait()
 	ec2i.parentWg.Done()
 }
 
 // describeInstances wraps ec2 pagination for DescribeInstances
 func describeInstances(client ec2.Client, c chan<- ec2.Instance) {
+	wg := sync.WaitGroup{}
 	defer close(c)
 	input := &ec2.DescribeInstancesInput{}
 	req := client.DescribeInstancesRequest(input)
 	p := ec2.NewDescribeInstancesPaginator(req)
 	for p.Next(context.TODO()) {
-		for _, runInstancesOutput := range p.CurrentPage().Reservations {
-			for _, instance := range runInstancesOutput.Instances {
-				c <- instance
+		wg.Add(1)
+		go func() {
+			for _, runInstancesOutputL := range p.CurrentPage().Reservations {
+				runInstancesOutput := runInstancesOutputL
+				wg.Add(1)
+				go func() {
+					for _, instance := range runInstancesOutput.Instances {
+						c <- instance
+					}
+				}()
 			}
-		}
+		}()
 	}
+	wg.Wait()
 }

--- a/lib/searchrds/clusters.go
+++ b/lib/searchrds/clusters.go
@@ -3,6 +3,7 @@ package searchrds
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/Kaurin/megantory/lib/common"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -11,27 +12,34 @@ import (
 
 // searchClusters searches single AWS RDS region
 func searchClusters(rdsi rdsInput) {
+	wg := sync.WaitGroup{}
 	service := "rds"
 	resourceType := "rds-cluster"
 	bcr := common.BreadCrumbs(rdsi.profile, rdsi.region, service, resourceType)
 	cClusters := make(chan rds.DBCluster)
 	go describeClusters(rdsi.client, cClusters)
-	for cluster := range cClusters { // Blocked until describeClusters closes chan
-		clusterLower := strings.ToLower(cluster.String())
-		searchStrLower := strings.ToLower(rdsi.searchStr)
-		if strings.Contains(clusterLower, searchStrLower) {
-			result := common.Result{
-				Account:      rdsi.profile,
-				Region:       rdsi.region,
-				Service:      service,
-				ResourceType: resourceType,
-				ResourceID:   *cluster.DBClusterIdentifier,
-				ResourceJSON: cluster.String(),
+	for clusterL := range cClusters { // Blocked until describeClusters closes chan
+		cluster := clusterL
+		wg.Add(1)
+		go func() {
+			clusterLower := strings.ToLower(cluster.String())
+			searchStrLower := strings.ToLower(rdsi.searchStr)
+			if strings.Contains(clusterLower, searchStrLower) {
+				result := common.Result{
+					Account:      rdsi.profile,
+					Region:       rdsi.region,
+					Service:      service,
+					ResourceType: resourceType,
+					ResourceID:   *cluster.DBClusterIdentifier,
+					ResourceJSON: cluster.String(),
+				}
+				log.Debugf("%s: Matched a cluster, sending back to the results channel.", bcr)
+				rdsi.cResult <- result
 			}
-			log.Debugf("%s: Matched a cluster, sending back to the results channel.", bcr)
-			rdsi.cResult <- result
-		}
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 	rdsi.parentWg.Done()
 }
 

--- a/lib/searchrds/clusters.go
+++ b/lib/searchrds/clusters.go
@@ -18,7 +18,7 @@ func searchClusters(rdsi rdsInput) {
 	bcr := common.BreadCrumbs(rdsi.profile, rdsi.region, service, resourceType)
 	cClusters := make(chan rds.DBCluster)
 	go describeClusters(rdsi.client, cClusters)
-	for clusterL := range cClusters { // Blocked until describeClusters closes chan
+	for clusterL := range cClusters {
 		cluster := clusterL
 		wg.Add(1)
 		go func() {
@@ -33,7 +33,7 @@ func searchClusters(rdsi rdsInput) {
 					ResourceID:   *cluster.DBClusterIdentifier,
 					ResourceJSON: cluster.String(),
 				}
-				log.Debugf("%s: Matched a cluster, sending back to the results channel.", bcr)
+				log.Debugf("%s: Matched an %s, sending back to the results channel.", bcr, resourceType)
 				rdsi.cResult <- result
 			}
 			wg.Done()


### PR DESCRIPTION
As our code goes through profiles / regions / services and goes into
resource-level processing it has some text processing to do (at the moment).

Before this change, text processing would block each new resource coming
into the channel, but no longer. We're not processing every resource in it's
goroutine as it comes into the resource processing channel.

Bonus: Equalized ec2-instance, ec2-address and rds-cluster resource
searches so the code is similar.

Code in these functions does look quite duplicated, but I'm not sure if I'll be 
able to break this down any better.