### PR TITLE
More concurrency - more performance (#24)

### DIFF
--- a/lib/searchec2/addresses.go
+++ b/lib/searchec2/addresses.go
@@ -3,6 +3,7 @@ package searchec2
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/Kaurin/megantory/lib/common"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -11,24 +12,34 @@ import (
 
 // searchAddresses searches single AWS EC2 region
 func searchAddresses(ec2i ec2Input) {
+	wg := sync.WaitGroup{}
+	service := "ec2"
+	resourceType := "ec2-address"
+	bcr := common.BreadCrumbs(ec2i.profile, ec2i.region, service, resourceType)
 	cAddresses := make(chan ec2.Address)
 	go describeAddresses(ec2i.client, ec2i.profile, cAddresses)
-	for address := range cAddresses {
-		addressLower := strings.ToLower(address.String())
-		searchStrLower := strings.ToLower(ec2i.searchStr)
-		if strings.Contains(addressLower, searchStrLower) {
-			result := common.Result{
-				Account:      ec2i.profile,
-				Region:       ec2i.region,
-				Service:      "ec2",
-				ResourceType: "ec2-address",
-				ResourceID:   *address.AllocationId,
-				ResourceJSON: address.String(),
+	for addressL := range cAddresses {
+		address := addressL
+		wg.Add(1)
+		go func() {
+			addressLower := strings.ToLower(address.String())
+			searchStrLower := strings.ToLower(ec2i.searchStr)
+			if strings.Contains(addressLower, searchStrLower) {
+				result := common.Result{
+					Account:      ec2i.profile,
+					Region:       ec2i.region,
+					Service:      service,
+					ResourceType: resourceType,
+					ResourceID:   *address.AllocationId,
+					ResourceJSON: address.String(),
+				}
+				log.Debugf("%s: Matched an %s, sending back to the results channel.", bcr, resourceType)
+				ec2i.cResult <- result
 			}
-			log.Debugln("EC2: Matched an address, sending back to the results channel.")
-			ec2i.cResult <- result
-		}
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 	ec2i.parentWg.Done()
 }
 

--- a/lib/searchec2/instances.go
+++ b/lib/searchec2/instances.go
@@ -3,6 +3,7 @@ package searchec2
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/Kaurin/megantory/lib/common"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -11,27 +12,35 @@ import (
 
 // searchInstances searches single AWS EC2 region
 func searchInstances(ec2i ec2Input) {
+	wg := sync.WaitGroup{}
 	service := "ec2"
 	resourceType := "ec2-instance"
 	bcr := common.BreadCrumbs(ec2i.profile, ec2i.region, service, resourceType)
 	cInstances := make(chan ec2.Instance)
 	go describeInstances(ec2i.client, cInstances)
-	for instance := range cInstances { // Blocked until describeInstances closes chan
-		instanceLower := strings.ToLower(instance.String())
-		searchStrLower := strings.ToLower(ec2i.searchStr)
-		if strings.Contains(instanceLower, searchStrLower) {
-			result := common.Result{
-				Account:      ec2i.profile,
-				Region:       ec2i.region,
-				Service:      service,
-				ResourceType: resourceType,
-				ResourceID:   *instance.InstanceId,
-				ResourceJSON: instance.String(),
+	for instanceL := range cInstances {
+		instance := instanceL
+		wg.Add(1)
+		go func() {
+			instanceLower := strings.ToLower(instance.String())
+			searchStrLower := strings.ToLower(ec2i.searchStr)
+			if strings.Contains(instanceLower, searchStrLower) {
+				result := common.Result{
+					Account:      ec2i.profile,
+					Region:       ec2i.region,
+					Service:      service,
+					ResourceType: resourceType,
+					ResourceID:   *instance.InstanceId,
+					ResourceJSON: instance.String(),
+				}
+				log.Debugf("%s: Matched an %s, sending back to the results channel.", bcr, resourceType)
+				ec2i.cResult <- result
 			}
-			log.Debugf("%s: Matched an instance, sending back to the results channel.", bcr)
-			ec2i.cResult <- result
-		}
+			wg.Done()
+		}()
+
 	}
+	wg.Wait()
 	ec2i.parentWg.Done()
 }
 

--- a/lib/searchrds/clusters.go
+++ b/lib/searchrds/clusters.go
@@ -3,6 +3,7 @@ package searchrds
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/Kaurin/megantory/lib/common"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -11,27 +12,34 @@ import (
 
 // searchClusters searches single AWS RDS region
 func searchClusters(rdsi rdsInput) {
+	wg := sync.WaitGroup{}
 	service := "rds"
 	resourceType := "rds-cluster"
 	bcr := common.BreadCrumbs(rdsi.profile, rdsi.region, service, resourceType)
 	cClusters := make(chan rds.DBCluster)
 	go describeClusters(rdsi.client, cClusters)
-	for cluster := range cClusters { // Blocked until describeClusters closes chan
-		clusterLower := strings.ToLower(cluster.String())
-		searchStrLower := strings.ToLower(rdsi.searchStr)
-		if strings.Contains(clusterLower, searchStrLower) {
-			result := common.Result{
-				Account:      rdsi.profile,
-				Region:       rdsi.region,
-				Service:      service,
-				ResourceType: resourceType,
-				ResourceID:   *cluster.DBClusterIdentifier,
-				ResourceJSON: cluster.String(),
+	for clusterL := range cClusters {
+		cluster := clusterL
+		wg.Add(1)
+		go func() {
+			clusterLower := strings.ToLower(cluster.String())
+			searchStrLower := strings.ToLower(rdsi.searchStr)
+			if strings.Contains(clusterLower, searchStrLower) {
+				result := common.Result{
+					Account:      rdsi.profile,
+					Region:       rdsi.region,
+					Service:      service,
+					ResourceType: resourceType,
+					ResourceID:   *cluster.DBClusterIdentifier,
+					ResourceJSON: cluster.String(),
+				}
+				log.Debugf("%s: Matched an %s, sending back to the results channel.", bcr, resourceType)
+				rdsi.cResult <- result
 			}
-			log.Debugf("%s: Matched a cluster, sending back to the results channel.", bcr)
-			rdsi.cResult <- result
-		}
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 	rdsi.parentWg.Done()
 }
 


### PR DESCRIPTION
As our code goes through profiles / regions / services and goes into
resource-level processing it has some text processing to do (at the moment).

Before this change, text processing would block each new resource coming
into the channel, but no longer. We're not processing every resource in it's
goroutine as it comes into the resource processing channel.

Bonus: Equalized ec2-instance, ec2-address and rds-cluster resource
searches so the code is similar.

Code in these functions does look quite duplicated, but I'm not sure if I'll be 
able to break this down any better.